### PR TITLE
Expect Parser.Basics.Error exception for a failing test

### DIFF
--- a/tests/tests.t
+++ b/tests/tests.t
@@ -30,7 +30,7 @@
   $ $PARSECMD < $TESTDIR/dangling_else.c
 SHOULD FAIL:
   $ $PARSECMD < $TESTDIR/dangling_else_misleading.fail.c
-  Fatal error: exception Parser.Error
+  Fatal error: exception Parser.Basics.Error
   [2]
   $ $PARSECMD < $TESTDIR/dangling_else_lookahead.c
   $ $PARSECMD < $TESTDIR/dangling_else_lookahead.if.c


### PR DESCRIPTION
Without this pull request, I got the following error when I ran `make test`

```
$ make test
ocamlbuild -menhir "menhir --no-stdlib --unused-token IMAGINARY -lg 1 -la 1 -v" main.native
Finished, 0 targets (0 cached) in 00:00:00.
Finished, 31 targets (31 cached) in 00:00:00.
mv main.native parse
cram tests/tests.t
!
--- tests/tests.t
+++ tests/tests.t.err
@@ -30,7 +30,7 @@
   $ $PARSECMD < $TESTDIR/dangling_else.c
 SHOULD FAIL:
   $ $PARSECMD < $TESTDIR/dangling_else_misleading.fail.c
-  Fatal error: exception Parser.Error
+  Fatal error: exception Parser.Basics.Error
   [2]
   $ $PARSECMD < $TESTDIR/dangling_else_lookahead.c
   $ $PARSECMD < $TESTDIR/dangling_else_lookahead.if.c

# Ran 1 tests, 0 skipped, 1 failed.
Makefile:20: recipe for target 'test' failed
make: *** [test] Error 1
```