### PR TITLE
remove invalid "alignof" reserved word

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -48,7 +48,6 @@ let () =
       ("_Noreturn", NORETURN);
       ("_Static_assert", STATIC_ASSERT);
       ("_Thread_local", THREAD_LOCAL);
-      ("alignof", ALIGNOF);
       ("auto", AUTO);
       ("break", BREAK);
       ("case", CASE);


### PR DESCRIPTION
The correct keyword, `_Alignof`, is already parsed as the same token
identifier. `alignof` is available as a macro defined by `<stdalign.h>` but is not a
valid keyword of the language.

Originally reported in: #5 