### PR TITLE
A big and a small change to the lexer

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -34,55 +34,6 @@ open Context
 open Parser
 open Options
 
-let lexicon : (string, token) Hashtbl.t = Hashtbl.create 17
-
-let () =
-  List.iter (fun (key, builder) -> Hashtbl.add lexicon key builder)
-    [ ("_Alignas", ALIGNAS);
-      ("_Alignof", ALIGNOF);
-      ("_Atomic", ATOMIC);
-      ("_Bool", BOOL);
-      ("_Complex", COMPLEX);
-      ("_Generic", GENERIC);
-      ("_Imaginary", IMAGINARY);
-      ("_Noreturn", NORETURN);
-      ("_Static_assert", STATIC_ASSERT);
-      ("_Thread_local", THREAD_LOCAL);
-      ("auto", AUTO);
-      ("break", BREAK);
-      ("case", CASE);
-      ("char", CHAR);
-      ("const", CONST);
-      ("continue", CONTINUE);
-      ("default", DEFAULT);
-      ("do", DO);
-      ("double", DOUBLE);
-      ("else", ELSE);
-      ("enum", ENUM);
-      ("extern", EXTERN);
-      ("float", FLOAT);
-      ("for", FOR);
-      ("goto", GOTO);
-      ("if", IF);
-      ("inline", INLINE);
-      ("int", INT);
-      ("long", LONG);
-      ("register", REGISTER);
-      ("restrict", RESTRICT);
-      ("return", RETURN);
-      ("short", SHORT);
-      ("signed", SIGNED);
-      ("sizeof", SIZEOF);
-      ("static", STATIC);
-      ("struct", STRUCT);
-      ("switch", SWITCH);
-      ("typedef", TYPEDEF);
-      ("union", UNION);
-      ("unsigned", UNSIGNED);
-      ("void", VOID);
-      ("volatile", VOLATILE);
-      ("while", WHILE)]
-
 let init _filename channel : Lexing.lexbuf =
   Lexing.from_channel channel
 
@@ -235,9 +186,51 @@ rule initial = parse
   | ";"                           { SEMICOLON }
   | ","                           { COMMA }
   | "."                           { DOT }
-  | identifier as id              {
-      try Hashtbl.find lexicon id
-      with Not_found -> NAME id }
+  | "_Alignas"                    { ALIGNAS }
+  | "_Alignof"                    { ALIGNOF }
+  | "_Atomic"                     { ATOMIC }
+  | "_Bool"                       { BOOL }
+  | "_Complex"                    { COMPLEX }
+  | "_Generic"                    { GENERIC }
+  | "_Imaginary"                  { IMAGINARY }
+  | "_Noreturn"                   { NORETURN }
+  | "_Static_assert"              { STATIC_ASSERT }
+  | "_Thread_local"               { THREAD_LOCAL }
+  | "auto"                        { AUTO }
+  | "break"                       { BREAK }
+  | "case"                        { CASE }
+  | "char"                        { CHAR }
+  | "const"                       { CONST }
+  | "continue"                    { CONTINUE }
+  | "default"                     { DEFAULT }
+  | "do"                          { DO }
+  | "double"                      { DOUBLE }
+  | "else"                        { ELSE }
+  | "enum"                        { ENUM }
+  | "extern"                      { EXTERN }
+  | "float"                       { FLOAT }
+  | "for"                         { FOR }
+  | "goto"                        { GOTO }
+  | "if"                          { IF }
+  | "inline"                      { INLINE }
+  | "int"                         { INT }
+  | "long"                        { LONG }
+  | "register"                    { REGISTER }
+  | "restrict"                    { RESTRICT }
+  | "return"                      { RETURN }
+  | "short"                       { SHORT }
+  | "signed"                      { SIGNED }
+  | "sizeof"                      { SIZEOF }
+  | "static"                      { STATIC }
+  | "struct"                      { STRUCT }
+  | "switch"                      { SWITCH }
+  | "typedef"                     { TYPEDEF }
+  | "union"                       { UNION }
+  | "unsigned"                    { UNSIGNED }
+  | "void"                        { VOID }
+  | "volatile"                    { VOLATILE }
+  | "while"                       { WHILE }
+  | identifier as id              { NAME id }
   | eof                           { EOF }
   | _                             { failwith "Lexer error" }
 

--- a/lexer.mll
+++ b/lexer.mll
@@ -262,7 +262,8 @@ and string_literal = parse
 and hash = parse
   | whitespace_char_no_newline+ decimal_constant whitespace_char_no_newline*
     "\"" [^ '\n' '\"']* "\"" [^ '\n']* '\n'
-  | whitespace_char_no_newline* "pragma" whitespace_char_no_newline+ [^ '\n']* '\n'
+  | whitespace_char_no_newline* "pragma"
+    whitespace_char_no_newline+ [^ '\n']* '\n'
       { initial_linebegin lexbuf }
   | [^ '\n']* eof
       { failwith "unexpected end of file" }


### PR DESCRIPTION
1. Big change: convert from using a hash table for recognizing keywords to just throwing it in to the regular expression engine. This is conceptually clearer, and given that there are fairly few keywords, probably as or more efficient.

2. Small change: make a trivial modification to keep lines under 80 columns.

I'm probably going to make a few more largely cosmetic changes to the lexer for readability as well. I'm gearing up to add a lexer for preprocessor tokens in the same file in preparation for constructing a (hopefully correct) implementation of the preprocessor, and I'm trying to get things pretty. (If this isn't of interest, I can do the work in my own fork.)

[Edited to add: I'm not 100% sure that keeping the cpp tokenizer in the same file is a good idea. I'll figure that bit out as I try it...]