### PR TITLE
after a single line comment, we are at the beginning of a line

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -133,7 +133,7 @@ rule initial = parse
   | whitespace_char_no_newline+   { initial lexbuf }
   | '\n'                          { new_line lexbuf; initial_linebegin lexbuf }
   | "/*"                          { multiline_comment lexbuf; initial lexbuf }
-  | "//"                          { singleline_comment lexbuf; initial lexbuf }
+  | "//"                          { singleline_comment lexbuf; initial_linebegin lexbuf }
   | integer_constant              { CONSTANT }
   | decimal_floating_constant     { CONSTANT }
   | hexadecimal_floating_constant { CONSTANT }


### PR DESCRIPTION
This is a minor bug: the lexer misses the fact that after a single line comment, we are at the beginning of a line. Therefore `#` directives are missed after a single line comment.

One could argue that a proper preprocessor would have removed comments, and therefore either you have comments or you have line directives... But the lexer already tries to handle some of these situations, so this is a "best effort" attempt.

Here is a sample file that fails with "Lexer error" without the patch:

```c
// Test
# 3 "test.c"
int test;
```