### PR TITLE
Add grammar rule to accept adjacent string literals

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -57,7 +57,7 @@ let identifier_nondigit =
 let identifier = identifier_nondigit (identifier_nondigit|digit)*
 
 (* Whitespaces *)
-let whitespace_char_no_newline = [' ' '\t' '\012' '\r']
+let whitespace_char_no_newline = [' ' '\t' '\r']
 
 (* Integer constants *)
 let nonzero_digit = ['1'-'9']

--- a/parser.mly
+++ b/parser.mly
@@ -275,7 +275,7 @@ declarator_typedefname:
 primary_expression:
 | var_name
 | CONSTANT
-| STRING_LITERAL
+| string_literal
 | "(" expression ")"
 | generic_selection
     {}
@@ -707,7 +707,7 @@ designator:
     {}
 
 static_assert_declaration:
-| "_Static_assert" "(" constant_expression "," STRING_LITERAL ")" ";"
+| "_Static_assert" "(" constant_expression "," string_literal ")" ";"
     {}
 
 statement:
@@ -785,4 +785,9 @@ function_definition:
 declaration_list:
 | declaration
 | declaration_list declaration
+    {}
+
+string_literal:
+| STRING_LITERAL
+| string_literal STRING_LITERAL
     {}

--- a/parser.y
+++ b/parser.y
@@ -393,7 +393,7 @@ primary_expression:
     {}
 | CONSTANT
     {}
-| STRING_LITERAL
+| string_literal
     {}
 | LPAREN expression RPAREN
     {}
@@ -921,7 +921,7 @@ designator:
     {}
 
 static_assert_declaration:
-  STATIC_ASSERT LPAREN constant_expression COMMA STRING_LITERAL RPAREN SEMICOLON
+  STATIC_ASSERT LPAREN constant_expression COMMA string_literal RPAREN SEMICOLON
     {}
 
 statement:
@@ -1016,6 +1016,12 @@ declaration_list:
   declaration
     {}
 | declaration_list declaration
+    {}
+
+string_literal:
+  STRING_LITERAL
+    {}
+| string_literal STRING_LITERAL
     {}
 
 %%

--- a/tests/concatenated_strings.c
+++ b/tests/concatenated_strings.c
@@ -1,0 +1,3 @@
+char* s = "abc" "def";
+char* t = "ghij"
+          "klmnop";

--- a/tests/tests.t
+++ b/tests/tests.t
@@ -42,6 +42,7 @@ SHOULD FAIL (does not because we do not have a semantic analysis):
   $ $PARSECMD < $TESTDIR/bitfield_declaration_ambiguity.ok.c
   $ $PARSECMD < $TESTDIR/atomic_parenthesis.c
   $ $PARSECMD < $TESTDIR/aligned_struct_c18.c
+  $ $PARSECMD < $TESTDIR/concatenated_strings.c
   $ ls $TESTDIR/*.c
   */tests/aligned_struct_c18.c (glob)
   */tests/argument_scope.c (glob)
@@ -55,6 +56,7 @@ SHOULD FAIL (does not because we do not have a semantic analysis):
   */tests/c11-noreturn.c (glob)
   */tests/c1x-alignas.c (glob)
   */tests/char-literal-printing.c (glob)
+  */tests/concatenated_strings.c (glob)
   */tests/control-scope.c (glob)
   */tests/dangling_else.c (glob)
   */tests/dangling_else_lookahead.c (glob)


### PR DESCRIPTION
Also fix `whitespace_char_no_newline` pattern to exclude newline `\012`